### PR TITLE
feat: enable dynamic zone discovery and restrict records to those zones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +675,7 @@ dependencies = [
 name = "opnsense_unbound_external-dns_webhook"
 version = "0.2.0-rc1"
 dependencies = [
+ "anyhow",
  "axum",
  "figment",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "opnsense unbound external-dns webhook"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+anyhow = "1.0.86"
 axum = "0.7.4"
 figment = { version = "0.10", features = ["yaml", "env"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 mod external_dns;
 mod opnsense;
+mod state;
 
 use axum::{
     extract::State,
@@ -9,20 +10,13 @@ use axum::{
     Json, Router,
 };
 use config::Config;
-use external_dns::{Changes, Edns, Endpoint, Endpoints, Filters, Targets};
-use opnsense::unbound;
+use external_dns::{Changes, DomainFilter, Edns, Endpoint, Endpoints};
 use opnsense::Opnsense;
-use std::collections::HashMap;
+use state::{AppState, DefaultRecordCache, DefaultZoneCache, RecordCache, ZoneCache};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 use tower_http::trace::{self, TraceLayer};
 use tracing::instrument;
-
-struct AppState {
-    config: Config,
-    opnsense: Opnsense,
-    uuid_map: Mutex<HashMap<String, String>>,
-}
 
 pub struct Server {
     config: Config,
@@ -35,12 +29,13 @@ impl From<Config> for Server {
 }
 
 impl Server {
-    pub async fn serve(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let state = Arc::new(AppState {
+    pub async fn serve(&self) -> anyhow::Result<()> {
+        let state = AppState {
             opnsense: Opnsense::try_from(&self.config)?,
             config: self.config.clone(),
-            uuid_map: Mutex::new(HashMap::new()),
-        });
+            record_cache: Arc::new(RwLock::new(DefaultRecordCache::new())),
+            zone_cache: Arc::new(RwLock::new(DefaultZoneCache::new())),
+        };
 
         let app = Router::new()
             .route("/", get(negotiate))
@@ -62,20 +57,33 @@ impl Server {
     }
 }
 
+// negotiate retrieves filtered zones from Opnsense
+// and responds to external-dns with zone filters.
 #[instrument(skip(state))]
-async fn negotiate(State(state): State<Arc<AppState>>) -> Result<Edns<Filters>, StatusCode> {
-    //TODO: the rest of the implementation doesn't check is domains are valid in regards with those filters
+async fn negotiate<R: RecordCache, Z: ZoneCache>(
+    State(state): State<AppState<R, Z>>,
+) -> Result<Edns<DomainFilter>, StatusCode> {
+    let zones = zones(&state)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    Ok(Edns(Filters {
-        filters: state.config.domain_filters.clone(),
+    tracing::info!(?zones, "replying with filtered zones");
+
+    Ok(Edns(DomainFilter {
+        filters: state.zone_cache.read().await.values(),
     }))
 }
 
 #[instrument(skip(_state))]
-async fn healthz(State(_state): State<Arc<AppState>>) -> () {}
+async fn healthz<R: RecordCache, Z: ZoneCache>(State(_state): State<AppState<R, Z>>) -> () {}
 
+// Gets existing host overrides and filters by managed zones
+// Updates UUID map to map records to their UUID's
+// Returns "enabled" records as endpoints
 #[instrument(skip(state))]
-async fn get_records(State(state): State<Arc<AppState>>) -> Result<Edns<Endpoints>, StatusCode> {
+async fn get_records<R: RecordCache, Z: ZoneCache>(
+    State(state): State<AppState<R, Z>>,
+) -> Result<Edns<Endpoints>, StatusCode> {
     let list = state
         .opnsense
         .unbound()
@@ -84,118 +92,303 @@ async fn get_records(State(state): State<Arc<AppState>>) -> Result<Edns<Endpoint
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let mut guard = state.uuid_map.lock().await;
+    let zones = zones(&state)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let records = list.rows.into_iter().filter(|r| zones.contains(&r.domain));
+
+    let mut guard = state.record_cache.write().await;
+
     guard.clear();
-    for r in list.rows.iter() {
-        let _ = guard.insert(r.domain.clone(), r.uuid.clone());
+
+    for r in records.clone() {
+        guard
+            .try_insert_record(&r)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     }
-    tracing::debug!("new uuid map: {:?}", guard);
+
     drop(guard);
 
-    Ok(Edns(Endpoints(
-        list.rows
-            .into_iter()
-            .filter(|r| r.enabled == "1")
-            .map(Endpoint::from)
-            .collect(),
+    Ok(Edns(Endpoints::from_iter(
+        records.filter(|r| r.enabled == "1").map(Into::into),
     )))
 }
 
-#[instrument(skip(state))]
-async fn set_records(
-    State(state): State<Arc<AppState>>,
+#[instrument(skip(state, changes))]
+async fn set_records<R: RecordCache, Z: ZoneCache>(
+    State(state): State<AppState<R, Z>>,
     Json(changes): Json<Changes>,
 ) -> Result<StatusCode, StatusCode> {
-    let mut need_restart = false;
+    let (creates, updates, deletes) = process_changes(&state, changes)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    for ep in changes
+    let results = [
+        create_records(&state, creates).await,
+        update_records(&state, updates).await,
+        delete_records(&state, deletes).await,
+    ]
+    .into_iter()
+    .collect::<Result<Vec<_>, _>>();
+
+    match results {
+        Ok(res) => {
+            for out in &res {
+                tracing::info!("{}", out);
+            }
+
+            if res.iter().any(|o| o.requires_restart()) {
+                let _ = state.opnsense.unbound().service().restart().await;
+            }
+
+            Ok(StatusCode::NO_CONTENT)
+        }
+        Err(e) => {
+            tracing::error!("{e}");
+
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+async fn process_changes<R: RecordCache, Z: ZoneCache>(
+    state: &AppState<R, Z>,
+    changes: Changes,
+) -> anyhow::Result<(
+    Vec<opnsense::unbound::HostOverrideRecord>,
+    Vec<opnsense::unbound::HostOverrideRecord>,
+    Vec<opnsense::unbound::HostOverrideRecord>,
+)> {
+    let zones = zones(state).await?;
+
+    let mut creates: Vec<opnsense::unbound::HostOverrideRecord> = vec![];
+    let mut updates: Vec<opnsense::unbound::HostOverrideRecord> = changes
+        .update_new
+        .into_iter()
+        .flat_map(|ep| ep.get_record_for_zones(&zones))
+        .collect();
+    let deletes: Vec<opnsense::unbound::HostOverrideRecord> = changes
+        .delete
+        .into_iter()
+        .flat_map(|ep| ep.get_record_for_zones(&zones))
+        .collect();
+
+    let guard = state.record_cache.read().await;
+
+    for record in changes
         .create
-        .0
-        .iter()
-        .map(|c| unbound::Row::from(c.clone()))
+        .into_iter()
+        .flat_map(|ep| ep.get_record_for_zones(&zones))
     {
+        match guard.try_get_record(&record)? {
+            Some(e) if e.enabled => continue,
+            Some(_) => updates.push(record),
+            None => creates.push(record),
+        }
+    }
+
+    Ok((creates, updates, deletes))
+}
+
+#[instrument(skip(state, creates))]
+async fn create_records<R: RecordCache, Z: ZoneCache>(
+    state: &AppState<R, Z>,
+    creates: impl IntoIterator<Item = opnsense::unbound::HostOverrideRecord>,
+) -> anyhow::Result<Output> {
+    let mut output = Output::new(Operation::Create);
+
+    for mut record in creates {
+        output.records_requested += 1;
+
         let res = state
             .opnsense
             .unbound()
             .settings()
-            .add_host_override(&ep)
+            .add_host_override(&record)
+            .await?;
+
+        tracing::debug!(?record, "added host override");
+
+        output.records_processed += 1;
+
+        record.uuid = res.uuid;
+
+        state
+            .record_cache
+            .write()
             .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-        let mut guard = state.uuid_map.lock().await;
-        guard.insert(ep.domain.clone(), res.uuid);
-        need_restart = true;
+            .try_insert_record(&record)?;
     }
 
-    for ep in changes
-        .update_new
-        .0
-        .iter()
-        .map(|c| unbound::Row::from(c.clone()))
-    {
-        let guard = state.uuid_map.lock().await;
-        if let Some(uuid) = guard.get(&ep.domain) {
-            if let Err(e) = state
-                .opnsense
-                .unbound()
-                .settings()
-                .set_host_override(uuid, &ep)
-                .await
-            {
-                tracing::error!("update: {:?}", e);
-                return Err(StatusCode::INTERNAL_SERVER_ERROR);
-            } else {
-                need_restart = true;
-            }
-        } else {
-            tracing::error!("update: could not find uuid in map: {:?}", &ep.domain);
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    for ep in changes.delete.0.iter() {
-        let mut guard = state.uuid_map.lock().await;
-        if let Some(uuid) = guard.get(&ep.dns_name) {
-            state
-                .opnsense
-                .unbound()
-                .settings()
-                .delete_host_override(uuid)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-            let _ = guard.remove(&ep.dns_name);
-            need_restart = true;
-        } else {
-            tracing::error!("delete: could not find uuid in map");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    if need_restart {
-        let _ = state.opnsense.unbound().service().restart().await;
-    }
-
-    Ok(StatusCode::NO_CONTENT)
+    Ok(output)
 }
-#[instrument(skip(_state))]
-async fn adjust_records(
-    State(_state): State<Arc<AppState>>,
-    Json(endpoints): Json<Endpoints>,
-) -> Result<Edns<Endpoints>, StatusCode> {
-    let mut results = Endpoints(Vec::new());
 
-    for ep in endpoints.0.iter() {
-        match ep.record_type.as_str() {
-            "A" | "AAAA" => {}
-            _ => continue,
+#[instrument(skip(state, updates))]
+async fn update_records<R: RecordCache, Z: ZoneCache>(
+    state: &AppState<R, Z>,
+    updates: impl IntoIterator<Item = opnsense::unbound::HostOverrideRecord>,
+) -> anyhow::Result<Output> {
+    let mut output = Output::new(Operation::Update);
+
+    let guard = state.record_cache.read().await;
+
+    for record in updates {
+        output.records_requested += 1;
+
+        let entry = guard.try_get_record(&record)?.ok_or(anyhow::anyhow!(
+            "could not find uuid in map: {}.{}",
+            &record.hostname,
+            &record.domain
+        ))?;
+
+        tracing::debug!(?entry, "updating host override");
+
+        output.records_processed += 1;
+
+        state
+            .opnsense
+            .unbound()
+            .settings()
+            .set_host_override(&entry.uuid, &record)
+            .await?;
+    }
+
+    Ok(output)
+}
+
+#[instrument(skip(state, deletes))]
+async fn delete_records<R: RecordCache, Z: ZoneCache>(
+    state: &AppState<R, Z>,
+    deletes: impl IntoIterator<Item = opnsense::unbound::HostOverrideRecord>,
+) -> anyhow::Result<Output> {
+    let mut output = Output::new(Operation::Delete);
+
+    let mut guard = state.record_cache.write().await;
+
+    for record in deletes.into_iter() {
+        output.records_requested += 1;
+
+        let entry = guard
+            .try_get_record(&record)?
+            .ok_or(anyhow::anyhow!("could not find uuid in map: {:?}", &record))?;
+
+        tracing::debug!(?entry, "deleting host override");
+
+        output.records_processed += 1;
+
+        state
+            .opnsense
+            .unbound()
+            .settings()
+            .delete_host_override(&entry.uuid)
+            .await?;
+
+        guard.try_remove_record(&record)?;
+    }
+
+    Ok(output)
+}
+
+struct Output {
+    operation: Operation,
+    pub records_requested: u64,
+    pub records_processed: u64,
+}
+
+impl Output {
+    pub fn new(op: Operation) -> Self {
+        Self {
+            operation: op,
+            records_requested: 0,
+            records_processed: 0,
+        }
+    }
+    pub fn requires_restart(&self) -> bool {
+        self.records_processed > 0
+    }
+}
+
+impl std::fmt::Display for Output {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}: records_requested: {}, records_processed: {}",
+            self.operation, self.records_requested, self.records_processed
+        )
+    }
+}
+
+enum Operation {
+    Create,
+    Update,
+    Delete,
+}
+
+impl std::fmt::Display for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Create => "create",
+            Self::Update => "update",
+            Self::Delete => "delete",
         };
 
-        results.0.push(Endpoint {
-            targets: Targets(ep.targets.0[..1].to_vec()),
-            record_ttl: None,
-            ..ep.clone()
-        });
+        write!(f, "{s}")
+    }
+}
+
+#[instrument(skip(_state))]
+async fn adjust_records<R: RecordCache, Z: ZoneCache>(
+    State(_state): State<AppState<R, Z>>,
+    Json(endpoints): Json<Endpoints>,
+) -> Result<Edns<Endpoints>, StatusCode> {
+    Ok(Edns(
+        endpoints
+            .into_iter()
+            .filter(|ep| ["A", "AAAA"].contains(&ep.record_type.as_str()))
+            .map(|ep| Endpoint {
+                record_ttl: None,
+                targets: (&ep.targets[0]).into(),
+                ..ep.clone()
+            })
+            .collect(),
+    ))
+}
+
+// zones retrieves zones from Opnsense, filters,
+// and caches them. Zones are returned from cache
+// on subsequent calls.
+#[instrument(skip(state))]
+async fn zones<R: RecordCache, Z: ZoneCache>(
+    state: &AppState<R, Z>,
+) -> anyhow::Result<Vec<String>> {
+    let filters = &state.config.domain_filters;
+    let mut guard = state.zone_cache.write().await;
+    let zones = guard.values();
+    if !zones.is_empty() {
+        return Ok(zones);
     }
 
-    Ok(Edns(results))
+    let zones = state
+        .opnsense
+        .unbound()
+        .diagnostics()
+        .list_local_zones()
+        .await?
+        .data
+        .iter()
+        .filter_map(|z| z.is_allowed_type().then_some(&z.zone))
+        .flat_map(|z| z.strip_suffix('.'))
+        .filter(|z| {
+            filters.is_empty()
+                || filters
+                    .iter()
+                    .map(|f| f.strip_prefix('.').unwrap_or(f))
+                    .any(|f| z.ends_with(f))
+        })
+        .map(Into::into)
+        .collect::<Vec<String>>();
+
+    guard.extend(zones.clone());
+
+    Ok(zones)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use opnsense_unbound_external_dns_webhook::{config::Config, Server};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> anyhow::Result<()> {
     let collector = tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .finish();

--- a/src/opnsense/mod.rs
+++ b/src/opnsense/mod.rs
@@ -5,7 +5,7 @@ pub mod unbound;
 use client::Client;
 use unbound::Unbound;
 
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+type Result<T> = anyhow::Result<T>;
 
 #[derive(Clone)]
 pub struct Opnsense {
@@ -19,7 +19,7 @@ impl Opnsense {
 }
 
 impl TryFrom<&Config> for Opnsense {
-    type Error = Box<dyn std::error::Error>;
+    type Error = anyhow::Error;
 
     fn try_from(config: &Config) -> std::result::Result<Self, Self::Error> {
         Ok(Self {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,150 @@
+use crate::config::Config;
+use crate::external_dns::Endpoint;
+use crate::opnsense::unbound::HostOverrideRecord;
+use crate::opnsense::Opnsense;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Clone)]
+pub struct AppState<R: RecordCache, Z: ZoneCache> {
+    pub config: Config,
+    pub opnsense: Opnsense,
+    pub record_cache: Arc<RwLock<R>>,
+    pub zone_cache: Arc<RwLock<Z>>,
+}
+
+pub trait RecordCache {
+    fn try_get_record(&self, record: &HostOverrideRecord) -> anyhow::Result<Option<RecordEntry>>;
+    fn try_insert_record(
+        &mut self,
+        record: &HostOverrideRecord,
+    ) -> anyhow::Result<Option<RecordEntry>>;
+    fn try_remove_record(&mut self, record: &HostOverrideRecord) -> anyhow::Result<()>;
+    fn clear(&mut self);
+}
+
+#[derive(Clone)]
+pub struct DefaultRecordCache(HashMap<Recordkey, RecordEntry>);
+
+impl DefaultRecordCache {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+}
+
+impl RecordCache for DefaultRecordCache {
+    fn try_get_record(&self, record: &HostOverrideRecord) -> anyhow::Result<Option<RecordEntry>> {
+        Ok(self.0.get(&record.try_into()?).cloned())
+    }
+    fn try_insert_record(
+        &mut self,
+        record: &HostOverrideRecord,
+    ) -> anyhow::Result<Option<RecordEntry>> {
+        Ok(self.0.insert(record.try_into()?, record.try_into()?))
+    }
+    fn try_remove_record(&mut self, record: &HostOverrideRecord) -> anyhow::Result<()> {
+        self.0.remove(&record.try_into()?);
+        Ok(())
+    }
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub struct Recordkey {
+    pub fqdn: String,
+    pub record_type: RecordType,
+}
+
+impl TryFrom<&HostOverrideRecord> for Recordkey {
+    type Error = anyhow::Error;
+    fn try_from(value: &HostOverrideRecord) -> Result<Self, Self::Error> {
+        Ok(Self {
+            fqdn: format!("{}.{}", value.hostname, value.domain),
+            record_type: value.rr.clone().try_into()?,
+        })
+    }
+}
+
+impl TryFrom<Endpoint> for Recordkey {
+    type Error = anyhow::Error;
+    fn try_from(value: Endpoint) -> Result<Self, Self::Error> {
+        Ok(Self {
+            fqdn: value.dns_name,
+            record_type: value.record_type.try_into()?,
+        })
+    }
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum RecordType {
+    A,
+    AAAA,
+}
+
+impl TryFrom<String> for RecordType {
+    type Error = anyhow::Error;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let value = value
+            .trim()
+            .split_once(' ')
+            .map(|v| v.0)
+            .unwrap_or(&value)
+            .to_uppercase();
+
+        Ok(match value.as_str() {
+            "A" => Self::A,
+            "AAAA" => Self::AAAA,
+            _ => Err(anyhow::anyhow!("unknown record type"))?,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RecordEntry {
+    pub uuid: String,
+    pub server: String,
+    pub enabled: bool,
+}
+
+impl TryFrom<&HostOverrideRecord> for RecordEntry {
+    type Error = anyhow::Error;
+    fn try_from(value: &HostOverrideRecord) -> Result<Self, Self::Error> {
+        Ok(RecordEntry {
+            uuid: value.uuid.clone(),
+            server: value.server.clone(),
+            enabled: match value.enabled.trim() {
+                "0" => false,
+                "1" => true,
+                _ => Err(anyhow::anyhow!("unknown enabled state"))?,
+            },
+        })
+    }
+}
+
+pub trait ZoneCache {
+    fn extend(&mut self, values: impl IntoIterator<Item = String>);
+    fn values(&self) -> Vec<String>;
+}
+
+#[derive(Clone)]
+pub struct DefaultZoneCache(HashSet<String>);
+
+impl DefaultZoneCache {
+    pub fn new() -> Self {
+        Self(HashSet::new())
+    }
+}
+
+impl ZoneCache for DefaultZoneCache {
+    fn extend(&mut self, values: impl IntoIterator<Item = String>) {
+        self.0.extend(values)
+    }
+    fn values(&self) -> Vec<String> {
+        self.0.clone().into_iter().collect()
+    }
+}


### PR DESCRIPTION
### Summary

First off, apologies for the large PR. I should've split this in to two, but ended doing more refactoring than I initially anticipated.

#### New features

- Added dynamic zone discovery during initial negotiation. Zones are cached for every subsequent call.
- Filter records by dynamic zones and not just `domain-filters`.

#### Breaking Changes

- Create explicit host overrides instead of using wildcard hosts for every record.
    1. External-dns will actually respect requests for wildcard hosts from sources so the previous behavior had the potential for issues.
    2. Unbound treats wildcard hosts as redirect zones deferring resolution to the target server of the wildcard record. This is probably unexpected behavior for end-users.

#### Fixes

- Ensure requests to re-enable host overrides are updates and not creates. I didn't spend too much time testing what happened when an override was disabled previously, but it looked like it would result in a duplicate record.
- Treat `A` and `AAAA` records for the same FQDN as unique. This is not a complete fix however since really we need to compare `update_old` and `update_new` to determine if a record changing type needs to be updated in-place.

#### Misc

- Use `anyhow` for errors just because `anyhow::Error` implements `Sync` allowing more freedom to refactor and pass around errors.
- Lots of little tweaks to improve ergonomics though `async` makes that challenging.

Built Image here: quay.io/ajpantuso/opnsense_unbound_external-dns_webhook@sha256:9d93426cf2278373108926361a2db0fc6048322d627c9217ea469c78173168a48